### PR TITLE
Merge schedule tree roundtrip work into `milestone2` integration branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -448,7 +448,7 @@ url = 'https://test.pypi.org/simple'
 [tool.uv.sources]
 atlas4py = {index = "test.pypi"}
 dace = [
-  {git = "https://github.com/GridTools/dace", branch = "romanc/stree-to-sdfg", group = "dace-cartesian"},
+  {git = "https://github.com/GridTools/dace", branch = "romanc/stree-roundtrip", group = "dace-cartesian"},
   {git = "https://github.com/GridTools/dace", tag = "__gt4py-next-integration_2025_07_29", group = "dace-next"}
 ]
 

--- a/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_treeir.py
@@ -61,10 +61,11 @@ class OIRToTreeIR(eve.NodeVisitor):
         self._device_type = device_type_translate[device_type.upper()]
         self._api_signature = builder.gtir.api_signature
         self._k_bounds = compute_k_boundary(builder.gtir)
+        self._vloop_sections = 0
 
     def visit_CodeBlock(self, node: oir.CodeBlock, ctx: tir.Context) -> None:
         dace_tasklet, inputs, outputs = oir_to_tasklet.OIRToTasklet().visit_CodeBlock(
-            node, root=ctx.root
+            node, root=ctx.root, scope=ctx.current_scope
         )
 
         tasklet = tir.Tasklet(
@@ -266,6 +267,9 @@ class OIRToTreeIR(eve.NodeVisitor):
         )
 
         loop = tir.VerticalLoop(
+            iteration_variable=eve.SymbolRef(
+                f"{tir.Axis.K.iteration_symbol()}_{self._vloop_sections}"
+            ),
             loop_order=loop_order,
             bounds_k=bounds,
             schedule=self._vertical_loop_schedule(),
@@ -275,6 +279,8 @@ class OIRToTreeIR(eve.NodeVisitor):
 
         with loop.scope(ctx):
             self.visit(node.horizontal_executions, ctx=ctx)
+
+        self._vloop_sections += 1
 
     def visit_VerticalLoop(self, node: oir.VerticalLoop, ctx: tir.Context) -> None:
         if node.caches:
@@ -399,9 +405,12 @@ class OIRToTreeIR(eve.NodeVisitor):
         for index, axis in enumerate(tir.Axis.dims_3d()):
             if ctx.root.dimensions[field.name][index]:
                 shift_str = f" + {shift[axis]}" if shift[axis] != 0 else ""
-                indices.append(
-                    f"{axis.iteration_symbol()}{shift_str} + {offset_dict[axis.lower()]}"
+                iteration_symbol = (
+                    tir.k_symbol(ctx.current_scope)
+                    if axis == tir.Axis.K
+                    else axis.iteration_symbol()
                 )
+                indices.append(f"{iteration_symbol}{shift_str} + {offset_dict[axis.lower()]}")
 
         return ", ".join(indices)
 
@@ -416,7 +425,7 @@ class OIRToTreeIR(eve.NodeVisitor):
         return (
             f"{tir.Axis.I.iteration_symbol()}{i_shift}, "
             f"{tir.Axis.J.iteration_symbol()}{j_shift}, "
-            f"{tir.Axis.K.iteration_symbol()}{k_shift} + {self.visit(node.k, ctx=ctx, **kwargs)}"
+            f"{tir.k_symbol(ctx.current_scope)}{k_shift} + {self.visit(node.k, ctx=ctx, **kwargs)}"
         )
 
     def visit_AbsoluteKIndex(
@@ -483,7 +492,12 @@ class OIRToTreeIR(eve.NodeVisitor):
 
         return f"({if_code} if {condition} else {else_code})"
 
-    def visit_IteratorAccess(self, node: oir.IteratorAccess, **kwargs: Any) -> str:
+    def visit_IteratorAccess(
+        self, node: oir.IteratorAccess, ctx: tir.Context, **kwargs: Any
+    ) -> str:
+        if node.name == "K":
+            return tir.k_symbol(ctx.current_scope)
+
         return tir.Axis(node.name).iteration_symbol()
 
     # visitors that should _not_ be called

--- a/src/gt4py/cartesian/gtc/dace/treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/treeir.py
@@ -81,9 +81,6 @@ class Axis(eve.StrEnum):
     def iteration_dace_symbol(self):
         return utils.get_dace_symbol(self.iteration_symbol())
 
-    def tile_dace_symbol(self):
-        return utils.get_dace_symbol(self.tile_symbol())
-
 
 class Bounds(eve.Node):
     start: str

--- a/src/gt4py/cartesian/gtc/dace/treeir.py
+++ b/src/gt4py/cartesian/gtc/dace/treeir.py
@@ -127,6 +127,12 @@ class HorizontalLoop(TreeScope):
 
 
 class VerticalLoop(TreeScope):
+    iteration_variable: eve.SymbolRef
+    """
+    DaCe 1.x (without CFGs) maps sequential loops to a state machine with the iteration variable
+    on inter state edges. Having unique symbols makes DaCe 1.x happy allows renaming symbols via
+    search & replace.
+    """
     loop_order: common.LoopOrder
     bounds_k: Bounds
 
@@ -147,3 +153,13 @@ class TreeRoot(TreeScope):
 
     symbols: SymbolDict
     """Mapping between type and symbol name."""
+
+
+def k_symbol(scope: TreeScope) -> eve.SymbolRef:
+    if scope.parent is None:
+        raise ValueError("No vertical loop found in (parents of) current scope.")
+
+    if isinstance(scope, VerticalLoop):
+        return scope.iteration_variable
+
+    return k_symbol(scope.parent)

--- a/src/gt4py/cartesian/gtc/dace/treeir_to_stree.py
+++ b/src/gt4py/cartesian/gtc/dace/treeir_to_stree.py
@@ -90,7 +90,7 @@ class TreeIRToScheduleTree(eve.NodeVisitor):
 
     def visit_VerticalLoop(self, node: tir.VerticalLoop, ctx: Context) -> None:
         # In any case, define the iteration symbol
-        ctx.tree.symbols[tir.Axis.K.iteration_symbol()] = dtypes.int32
+        ctx.tree.symbols[node.iteration_variable] = dtypes.int32
 
         # For serial loops, create a ForScope and add it to the tree
         if node.loop_order != common.LoopOrder.PARALLEL:
@@ -104,7 +104,7 @@ class TreeIRToScheduleTree(eve.NodeVisitor):
         # For parallel loops, create a map and add it to the tree
         dace_map = nodes.Map(
             label=f"vertical_loop_{id(node)}",
-            params=[tir.Axis.K.iteration_symbol()],
+            params=[node.iteration_variable],
             ndrange=subsets.Range(
                 # -1 because range bounds are inclusive
                 [(node.bounds_k.start, f"{node.bounds_k.end} - 1", 1)]
@@ -162,7 +162,7 @@ def _for_scope_header(node: tir.VerticalLoop) -> dcf.ForScope:
 
     plus_minus = "+" if node.loop_order == common.LoopOrder.FORWARD else "-"
     comparison = "<" if node.loop_order == common.LoopOrder.FORWARD else ">="
-    iteration_var = tir.Axis.K.iteration_symbol()
+    iteration_var = node.iteration_variable
 
     for_scope = dcf.ForScope(
         condition=CodeBlock(

--- a/uv.lock
+++ b/uv.lock
@@ -864,7 +864,7 @@ dependencies = [
 [[package]]
 name = "dace"
 version = "1.0.2"
-source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-to-sdfg#82541a9401dcadca43edc33cf1db61a0fe21d0e5" }
+source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-roundtrip#77dc937350e4fb5e0166c481993d1fa0f51d4ea2" }
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",
@@ -1334,7 +1334,7 @@ build = [
     { name = "wheel" },
 ]
 dace-cartesian = [
-    { name = "dace", version = "1.0.2", source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-to-sdfg#82541a9401dcadca43edc33cf1db61a0fe21d0e5" } },
+    { name = "dace", version = "1.0.2", source = { git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-roundtrip#77dc937350e4fb5e0166c481993d1fa0f51d4ea2" } },
 ]
 dace-next = [
     { name = "dace", version = "1.0.0", source = { git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_29#74bb66ac28b7e3965024bac080995136ce855f4e" } },
@@ -1476,7 +1476,7 @@ build = [
     { name = "setuptools", specifier = ">=77.0.3" },
     { name = "wheel", specifier = ">=0.33.6" },
 ]
-dace-cartesian = [{ name = "dace", git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-to-sdfg" }]
+dace-cartesian = [{ name = "dace", git = "https://github.com/GridTools/dace?branch=romanc%2Fstree-roundtrip" }]
 dace-next = [{ name = "dace", git = "https://github.com/GridTools/dace?tag=__gt4py-next-integration_2025_07_29" }]
 dev = [
     { name = "atlas4py", specifier = ">=0.41", index = "https://test.pypi.org/simple" },


### PR DESCRIPTION
## Description

This PR adds the work necessary in dace & gt4py to do validating roundtrip tests (in PyFV3 with the AI2 data) from the orchestrated SDFG to schedule tree and back to an SDFG. The work basically consists of two fixes

1. De-duplicating k-axis iteration symbols in the stree IR. If this step is omitted (as before), we shadow variables named `__k` (the k-axis iteration symbol) in case there are serial k-loops mixed with parallel k-maps. The SDFG -> stree conversion can't handle this and silently replaces the shadowing variables as if they weren't shadowing leading to hard-to-trace bugs. This is work done in gt4py.
2. Add support for properly translating SDFG -> stree in case of nested SDFGs with in/out connectors that are named the same. We get those in a couple places and we need to properly replace memlets inside the inlined SDFG with either the memlet flowing into the nested SDFG or going out of it. This is work done in dace.
