### PR TITLE
fix[cartesian]: Bugfix on absolute-k access on lower dimensional fields

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
+++ b/src/gt4py/cartesian/gtc/dace/oir_to_tasklet.py
@@ -406,10 +406,22 @@ def _memlet_subset_variable_offset(
     # Handle cartesian indices
     shift = ctx.tree.shift[node.name]
     offset_dict = node.offset.to_dict()
-    i = f"({tir.Axis.I.iteration_symbol()}) + ({shift[tir.Axis.I]}) + ({offset_dict[tir.Axis.I.lower()]})"
-    j = f"({tir.Axis.J.iteration_symbol()}) + ({shift[tir.Axis.J]}) + ({offset_dict[tir.Axis.J.lower()]})"
-    K = f"({tir.Axis.K.domain_symbol()}) + ({shift[tir.Axis.K]}) - 1"  # ranges are inclusive
-    ranges: list[tuple[str | int, str | int, int]] = [(i, i, 1), (j, j, 1), (0, K, 1)]
+    field_shape = ctx.tree.containers[node.name].shape
+    domain_indices: list[str] = []
+    for domain_axis in [
+        tir.Axis.I,
+        tir.Axis.J,
+    ]:
+        if domain_axis.domain_dace_symbol() in field_shape:
+            domain_indices.append(
+                f"({domain_axis.iteration_symbol()}) + ({shift[domain_axis]}) + ({offset_dict[domain_axis.lower()]})"
+            )
+
+    K_index = f"({tir.Axis.K.domain_symbol()}) + ({shift[tir.Axis.K]}) - 1"  # ranges are inclusive
+    ranges: list[tuple[str | int, str | int, int]] = []
+    for domain_index in domain_indices:
+        ranges.append((domain_index, domain_index, 1))
+    ranges.append((0, K_index, 1))
 
     # Append data dimensions
     for domain_size in data_domains:

--- a/src/gt4py/cartesian/gtc/debug/debug_codegen.py
+++ b/src/gt4py/cartesian/gtc/debug/debug_codegen.py
@@ -270,7 +270,17 @@ class DebugCodeGen(eve.VisitorWithSymbolTableTrait):
         return f"{field_access.name}[{offset_str}]"
 
     def visit_AbsoluteKIndex(self, absolute_k_index: oir.AbsoluteKIndex, **kwargs) -> str:
-        return f"i, j, int({self.visit(absolute_k_index.k, **kwargs)})"
+        access_pattern = []
+        if kwargs["dimensions"][2] is False:
+            raise ValueError(
+                "Tried accessing a field with no K-dimensions with an absolute K-index."
+            )
+        if kwargs["dimensions"][0]:
+            access_pattern.append("i")
+        if kwargs["dimensions"][1]:
+            access_pattern.append("j")
+        access_pattern.append(f"int({self.visit(absolute_k_index.k, **kwargs)})")
+        return ",".join(access_pattern)
 
     def visit_BinaryOp(self, binary: oir.BinaryOp, **kwargs) -> str:
         return f"( {self.visit(binary.left, **kwargs)} {binary.op} {self.visit(binary.right, **kwargs)} )"


### PR DESCRIPTION
## Description
We found that there was a bug with the implementation of absolute-k access and lower dimensional fields. This fixes the code-generation in both the debug and the dace-* backends.

The erroneous code that found this was:
```
def test_stencil(
    out_field: Field[np.float64],
    k_field: Field[K, np.float64],
):
    with computation(PARALLEL), interval(...):
        out_field[0, 0, 0] = k_field.at(K=3)
```

## Requirements

- [x] All fixes and/or new features come with corresponding tests.
- [ ] Important design decisions have been documented in the appropriate ADR inside the [docs/development/ADRs/](docs/development/ADRs/README.md) folder.
